### PR TITLE
Fix: Directory name infinite concatenation, also fixing issue #9

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func restoreTable(bucket, prefix, tableName string, batchSize int64, waitPeriod 
 	}
 
 	// Pull the manifest from s3 and load it to memory
-	err = store.LoadManifest(&storage.FileInput{Bucket: aws.String(bucket), Path: aws.String(fmt.Sprintf("%s/_SUCCESS", prefix))})
+	err = store.LoadManifest(&storage.FileInput{Bucket: aws.String(bucket), Path: aws.String(fmt.Sprintf("%s/manifest", prefix))})
 	if err != nil {
 		log.Fatalf("[ERROR] Unable to load the manifest flag information: %s\nAborting...\n", err)
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -146,7 +147,13 @@ func (h *S3Backup) WriteToDB(tableName string, batchSize int64, waitPeriod time.
 // DumpBuffer dumps the content of the given buffer to a new randomly generated
 // file name in the given s3 path in the given bucket and resets the said buffer
 func (h *S3Backup) DumpBuffer(input *FileInput, buff *bytes.Buffer) {
-	*input.Path = fmt.Sprintf("%s/%s", *input.Path, genNewFileName())
+	var splitPath = strings.Split(*input.Path, "/")
+	if len(splitPath) == 2 {
+		splitPath[1] = genNewFileName()
+		*input.Path = fmt.Sprintf("%s/%s", splitPath[0], splitPath[1])
+	} else {
+		*input.Path = fmt.Sprintf("%s/%s", *input.Path, genNewFileName())
+	}
 	if err := h.Flush(input, buff.Bytes()); err != nil {
 		log.Printf("[ERROR] while writing the file %s: %s", *input.Path, err)
 	}


### PR DESCRIPTION
When backing up starting from second iteration path created in function `DumpBuffer` is appended endlessly which makes S3 path look like: `s3://<Bucket Name>/<Directory Name>/a862fcbc-89f7-c10f-73dd-842aeb8e6686/27811c38-e9af-4da9-0f91-2e52fb756050/884b894c-bda8-6d03-239a-9588c64d820b/..`